### PR TITLE
FreeBSD backend switched to libusb 2.0

### DIFF
--- a/README
+++ b/README
@@ -3,7 +3,7 @@ devices as well as other hardware components.
 
 It supports the following OSes (at least this was the case at the time of
 writing):
-- FreeBSD (PCI via <sys/pciio.h>, USB via built-in libusb 1.0)
+- FreeBSD (PCI via <sys/pciio.h>, USB via built-in libusb 2.0)
 - macOS (PCI and USB via IOKit)
 - Linux (PCI and USB via sysfs)
 

--- a/lsuhwi.c
+++ b/lsuhwi.c
@@ -108,8 +108,7 @@ int main(const int argc, const char** argv) {
             format_as_json(first, stdout);
         else {
             if (type == UHWI_DEV_NULL)
-                fprintf(stdout, "[%s] ", (first->type == UHWI_DEV_USB) ? "USB" :
-                                                                     "PCI");
+                fprintf(stdout, "[%s] ", UHWI_DEV_TYPE_TO_CSTR(first->type));
 
             fprintf(stdout, "vendor=0x%04x, device=0x%04x", first->vendor,
                                                         first->device);

--- a/uhwi.c
+++ b/uhwi.c
@@ -128,7 +128,7 @@ typedef enum {
 }
 
 #define RESET_TOKEN(token, max, index) { \
-    memset(token, 0, sizeof(char) * max); \
+    memset(token, 0, max); \
     index = 0; \
 }
 
@@ -168,7 +168,7 @@ uhwi_dev* uhwi_db_init(void) {
 
     while (1) {
         char cc = '\0';
-        read(fd, &cc, sizeof(char));
+        read(fd, &cc, 1);
 
         if (cc == '\r' || cc == '\n' || cc == '\0') {
             // newline encountered
@@ -266,8 +266,8 @@ void uhwi_strncpy_pci_db_dev_name(uhwi_dev* current, uhwi_dev* db) {
 
 #ifdef __linux__
 #define COMBINE_PATH(base, label, fn) { \
-    memset(path, 0, sizeof(char) * PATH_MAX); \
-    snprintf(path, PATH_MAX, "%s/%s/%s", base, label, fn); \
+    memset(path, 0, PATH_MAX); \
+    snprintf(path, PATH_MAX - 1, "%s/%s/%s", base, label, fn); \
 }
 
 #define POPULATE_ID_FROM_PATH(result, path, prefixed, mandatory) { \
@@ -279,11 +279,10 @@ void uhwi_strncpy_pci_db_dev_name(uhwi_dev* current, uhwi_dev* db) {
             /* sysfs pseudo-file, which are probably in a format of a 4-digit */ \
             /* hexademical value prepended with a 0x */ \
             char pbuf[UHWI_PCI_PBSZ_CONST]; \
-            size_t pbsz = sizeof(char) * UHWI_PCI_PBSZ_CONST; \
             \
             /* read in pseudo-file contents into the buffer */ \
-            memset(pbuf, 0, pbsz); \
-            if (read(pfd, pbuf, pbsz) > 0) \
+            memset(pbuf, 0, UHWI_PCI_PBSZ_CONST); \
+            if (read(pfd, pbuf, UHWI_PCI_PBSZ_CONST) > 0) \
                 SSCANF_ID(pbuf, result, prefixed) \
             \
             /* clean up */ \
@@ -351,10 +350,9 @@ uhwi_dev* uhwi_cat_sysfs_pci_dev(const char* label, uhwi_dev* db) {
     \
     if (pfd) { \
         char pbuf[max]; \
-        size_t pbsz = sizeof(char) * max; \
+        memset(pbuf, 0, max); \
         \
-        memset(pbuf, 0, pbsz); \
-        ssize_t rdsz = read(pfd, pbuf, pbsz); \
+        ssize_t rdsz = read(pfd, pbuf, max); \
         \
         if (rdsz > 1) { \
             pbuf[rdsz - 1] = ' '; /* replace trailing newline to combine C strings */ \

--- a/uhwi.h
+++ b/uhwi.h
@@ -92,13 +92,11 @@ typedef enum {
     UHWI_ERRNO_PCI_IOCTL,
 
     //
-    // libusb 1.0 on FreeBSD
+    // proprietary semi-documented libusb 2.0 on FreeBSD
     //
 
-    // libusb_init() failed
+    // libusb_be_alloc_default() failed
     UHWI_ERRNO_USB_INIT,
-    // libusb_get_device_list() failed
-    UHWI_ERRNO_USB_LIST,
 
     //
     // sysfs on Linux


### PR DESCRIPTION
Although libusb 2.0 is a fairly undocumented API, this is the one that certainly works - FreeBSD's built-in control utilities, like ``usbconfig``, utilize it instead of the publicly well-known libusb 1.0. 

I have also found out that libusb 1.0 is also bad at detecting USB devices on modern FreeBSD systems - I'm still not sure why, but I suppose it's because this version uses an obsolete backend that is not tested anymore.

Right now the libusb 2.0 backend for libuhwi detects all the USB devices connected to the system as well as their information appropriately, at least that's what I have found as a part of me manually testing ``lsuhwi`` on various FreeBSD boxes.